### PR TITLE
Fix: Global Search respects selected module filter in UnifiedSearchAdvanced

### DIFF
--- a/lib/Search/ElasticSearch/ElasticSearchEngine.php
+++ b/lib/Search/ElasticSearch/ElasticSearchEngine.php
@@ -53,6 +53,7 @@ use SuiteCRM\Search\SearchWrapper;
 /**
  * SearchEngine that use Elasticsearch index for performing almost real-time search.
  */
+#[\AllowDynamicProperties]
 class ElasticSearchEngine extends SearchEngine
 {
     /** @var Client */
@@ -105,7 +106,8 @@ class ElasticSearchEngine extends SearchEngine
     {
         $searchStr = $query->getSearchString();
         $searchModules = SearchWrapper::getModules();
-        $indexes = implode(',', array_map('strtolower', $searchModules));
+
+        $indexes = (empty($query->getOption('module_only'))) ? implode(',', array_map('strtolower', $searchModules)) : $query->getOption('module_only');
 
         // Wildcard character required for Elasticsearch
         $wildcardBe = "*";


### PR DESCRIPTION

Fix: Global Search respects module filter in UnifiedSearchAdvanced

# Description
This change fixes a bug in the global search where selecting a specific module (e.g., "Opportunities") does not limit the results to that module. Currently, results from other modules are mixed in, and relevant results appear only on later pages (e.g., page 4 or 5), which leads to confusion and the false impression that there are no matches.

The fix ensures that when a module filter is selected, the search only returns and paginates results from that module.

# Motivation and Context
This improves the usability and accuracy of the global search. Users expect filtered search results to be immediately visible when selecting a specific module. Without this fix, users may overlook important data, believing no results were found.

## How To Test This

Log into SuiteCRM.

Use the global search (top-right) and search for the term Wagner.

In the module filter dropdown, select only Opportunities.

Click Search.

Before this fix: Results from Opportunities are only visible on later pages (page 4/5).

After this fix: Only Opportunity records are shown starting from page 1.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

New feature (non-breaking change which adds functionality)

Breaking change (fix or feature that would cause existing functionality to change)

Final checklist
My code follows the code style of this project found here.

My change requires a change to the documentation.

I have read the How to Contribute guidelines.